### PR TITLE
Shift+Enterでフォルダを開く際にカーソル行のフォルダを開くオプションの追加

### DIFF
--- a/Project/ShellFiler/src/Command/FileList/Tools/33OpenExplorerFolderCommand.cs
+++ b/Project/ShellFiler/src/Command/FileList/Tools/33OpenExplorerFolderCommand.cs
@@ -11,6 +11,7 @@ using ShellFiler.FileSystem.Virtual;
 using ShellFiler.FileTask;
 using ShellFiler.Util;
 using ShellFiler.UI;
+using System.IO;
 
 namespace ShellFiler.Command.FileList.Tools {
 
@@ -44,6 +45,13 @@ namespace ShellFiler.Command.FileList.Tools {
             }
 
             string folder = FileListViewTarget.FileList.DisplayDirectoryName;
+
+            if (Configuration.Current.FileListCursorOpenFolder) {
+                int lineNo = FileListComponentTarget.CursorLineNo;
+                string cursorFolderName = FileListViewTarget.FileList.Files[lineNo].FileName;
+                folder = System.IO.Path.Combine(folder, cursorFolderName);
+            }
+
             IFileListContext fileListCtx = FileListViewTarget.FileList.FileListContext;
             FileSystemFactory factory = Program.Document.FileSystemFactory;
             FileOperationStatus status = FileListViewTarget.FileList.FileSystem.OpenShellFile(folder, folder, true, fileListCtx);

--- a/Project/ShellFiler/src/Document/Configuration.cs
+++ b/Project/ShellFiler/src/Document/Configuration.cs
@@ -159,7 +159,10 @@ namespace ShellFiler.Document {
 
         // フォルダ変更時にカーソル位置のレジュームを行うときtrue
         private bool m_resumeFolderCursorFile = true;
-        
+
+        // フォルダオープン時にカーソル位置にあるフォルダを開くときtrue
+        private bool m_fileListCursorOpenFolder = false;
+
         //*****************************************************************************************
         // ファイル一覧＞起動時の表示モード
         //*****************************************************************************************
@@ -1041,6 +1044,8 @@ namespace ShellFiler.Document {
                     obj.m_hideWindowDragDrop = loader.BoolValue;
                 } else if (tagType == SettingTagType.BoolValue && tagName == SettingTag.Config_ResumeFolderCursorFile) {
                     obj.m_resumeFolderCursorFile = loader.BoolValue;
+                } else if (tagType == SettingTagType.BoolValue && tagName == SettingTag.Config_FileListCursorOpenFolder) {
+                    obj.m_fileListCursorOpenFolder = loader.BoolValue;
 
                 // ファイル一覧＞起動時の表示モード
                 } else if (tagType == SettingTagType.BeginObject && tagName == SettingTag.Config_DefaultViewModeLeft) {
@@ -1688,6 +1693,7 @@ namespace ShellFiler.Document {
             saver.AddBool(SettingTag.Config_ChdirParentOtherSideMove, obj.m_chdirParentOtherSideMove);
             saver.AddBool(SettingTag.Config_HideWindowDragDrop, obj.m_hideWindowDragDrop);
             saver.AddBool(SettingTag.Config_ResumeFolderCursorFile, obj.m_resumeFolderCursorFile);
+            saver.AddBool(SettingTag.Config_FileListCursorOpenFolder, obj.m_fileListCursorOpenFolder);
 
             // ファイル一覧＞起動時の表示モード
             saver.StartObject(SettingTag.Config_DefaultViewModeLeft);
@@ -2072,6 +2078,9 @@ namespace ShellFiler.Document {
                 return false;
             }
             if (obj1.m_resumeFolderCursorFile != obj2.m_resumeFolderCursorFile) {
+                return false;
+            }
+            if (obj1.m_fileListCursorOpenFolder != obj2.m_fileListCursorOpenFolder) {
                 return false;
             }
 
@@ -2645,6 +2654,7 @@ namespace ShellFiler.Document {
             clone.m_chdirParentOtherSideMove = m_chdirParentOtherSideMove;
             clone.m_hideWindowDragDrop = m_hideWindowDragDrop;
             clone.m_resumeFolderCursorFile = m_resumeFolderCursorFile;
+            clone.m_fileListCursorOpenFolder = m_fileListCursorOpenFolder;
 
             // ファイル一覧＞サムネイル
             if (m_defaultViewModeLeft != null) {
@@ -3570,6 +3580,18 @@ namespace ShellFiler.Document {
             }
             set {
                 m_resumeFolderCursorFile = value;
+            }
+        }
+
+        //=========================================================================================
+        // プロパティ：フォルダオープン時にカーソル位置にあるフォルダを開くときtrue
+        //=========================================================================================
+        public bool FileListCursorOpenFolder {
+            get {
+                return m_fileListCursorOpenFolder;
+            }
+            set {
+                m_fileListCursorOpenFolder = value;
             }
         }
 

--- a/Project/ShellFiler/src/Document/Setting/SettingTag.cs
+++ b/Project/ShellFiler/src/Document/Setting/SettingTag.cs
@@ -52,6 +52,7 @@ namespace ShellFiler.Document.Setting {
         public static readonly SettingTag Config_ChdirParentOtherSideMove           = Add(new SettingTag("ChdirParentOtherSideMove"));
         public static readonly SettingTag Config_HideWindowDragDrop                 = Add(new SettingTag("HideWindowDragDrop"));
         public static readonly SettingTag Config_ResumeFolderCursorFile             = Add(new SettingTag("ResumeFolderCursorFile"));
+        public static readonly SettingTag Config_FileListCursorOpenFolder           = Add(new SettingTag("FileListCursorOpenFolder"));
         public static readonly SettingTag Config_DefaultViewModeLeft                = Add(new SettingTag("DefaultViewModeLeft"));
         public static readonly SettingTag Config_DefaultViewModeRight               = Add(new SettingTag("DefaultViewModeRight"));
         public static readonly SettingTag Config_FileListViewChangeMode             = Add(new SettingTag("FileListViewChangeMode"));

--- a/Project/ShellFiler/src/UI/Dialog/Option/FileListActionPage.Designer.cs
+++ b/Project/ShellFiler/src/UI/Dialog/Option/FileListActionPage.Designer.cs
@@ -45,6 +45,7 @@ namespace ShellFiler.UI.Dialog.Option {
             this.label14 = new System.Windows.Forms.Label();
             this.label15 = new System.Windows.Forms.Label();
             this.checkBoxResumeCursor = new System.Windows.Forms.CheckBox();
+            this.checkFileListCursorOpenFolder = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.numericScrollMargin)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarWheel)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarDragMax)).BeginInit();
@@ -53,54 +54,54 @@ namespace ShellFiler.UI.Dialog.Option {
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(5, 10);
-            this.label1.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label1.Location = new System.Drawing.Point(4, 9);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(190, 30);
+            this.label1.Size = new System.Drawing.Size(164, 25);
             this.label1.TabIndex = 0;
             this.label1.Text = "スクロールマージン(&M):";
             // 
             // numericScrollMargin
             // 
-            this.numericScrollMargin.Location = new System.Drawing.Point(322, 7);
-            this.numericScrollMargin.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.numericScrollMargin.Location = new System.Drawing.Point(276, 6);
+            this.numericScrollMargin.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.numericScrollMargin.Maximum = new decimal(new int[] {
             5,
             0,
             0,
             0});
             this.numericScrollMargin.Name = "numericScrollMargin";
-            this.numericScrollMargin.Size = new System.Drawing.Size(210, 35);
+            this.numericScrollMargin.Size = new System.Drawing.Size(180, 31);
             this.numericScrollMargin.TabIndex = 1;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(542, 10);
-            this.label2.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label2.Location = new System.Drawing.Point(465, 9);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(34, 30);
+            this.label2.Size = new System.Drawing.Size(30, 25);
             this.label2.TabIndex = 2;
             this.label2.Text = "行";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(5, 147);
-            this.label3.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label3.Location = new System.Drawing.Point(4, 126);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(325, 30);
+            this.label3.Size = new System.Drawing.Size(280, 25);
             this.label3.TabIndex = 6;
             this.label3.Text = "マウスホイール回転時の最大速度(&W):";
             // 
             // trackBarWheel
             // 
-            this.trackBarWheel.Location = new System.Drawing.Point(396, 138);
-            this.trackBarWheel.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.trackBarWheel.Location = new System.Drawing.Point(339, 118);
+            this.trackBarWheel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.trackBarWheel.Maximum = 50;
             this.trackBarWheel.Minimum = 1;
             this.trackBarWheel.Name = "trackBarWheel";
-            this.trackBarWheel.Size = new System.Drawing.Size(182, 80);
+            this.trackBarWheel.Size = new System.Drawing.Size(156, 69);
             this.trackBarWheel.TabIndex = 8;
             this.trackBarWheel.TickFrequency = 5;
             this.trackBarWheel.Value = 1;
@@ -108,61 +109,61 @@ namespace ShellFiler.UI.Dialog.Option {
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(345, 147);
-            this.label4.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label4.Location = new System.Drawing.Point(296, 126);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(47, 30);
+            this.label4.Size = new System.Drawing.Size(41, 25);
             this.label4.TabIndex = 7;
             this.label4.Text = "遅く";
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(574, 147);
-            this.label5.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label5.Location = new System.Drawing.Point(492, 126);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(47, 30);
+            this.label5.Size = new System.Drawing.Size(41, 25);
             this.label5.TabIndex = 9;
             this.label5.Text = "速く";
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(5, 217);
-            this.label6.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label6.Location = new System.Drawing.Point(4, 186);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(305, 30);
+            this.label6.Size = new System.Drawing.Size(263, 25);
             this.label6.TabIndex = 10;
             this.label6.Text = "ドラッグ中の最大スクロール速度(&D):";
             // 
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(345, 217);
-            this.label7.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label7.Location = new System.Drawing.Point(296, 186);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(47, 30);
+            this.label7.Size = new System.Drawing.Size(41, 25);
             this.label7.TabIndex = 11;
             this.label7.Text = "遅く";
             // 
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(574, 217);
-            this.label8.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label8.Location = new System.Drawing.Point(492, 186);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(47, 30);
+            this.label8.Size = new System.Drawing.Size(41, 25);
             this.label8.TabIndex = 13;
             this.label8.Text = "速く";
             // 
             // trackBarDragMax
             // 
-            this.trackBarDragMax.Location = new System.Drawing.Point(396, 208);
-            this.trackBarDragMax.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.trackBarDragMax.Location = new System.Drawing.Point(339, 178);
+            this.trackBarDragMax.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.trackBarDragMax.Maximum = 50;
             this.trackBarDragMax.Minimum = 1;
             this.trackBarDragMax.Name = "trackBarDragMax";
-            this.trackBarDragMax.Size = new System.Drawing.Size(182, 80);
+            this.trackBarDragMax.Size = new System.Drawing.Size(156, 69);
             this.trackBarDragMax.TabIndex = 12;
             this.trackBarDragMax.TickFrequency = 5;
             this.trackBarDragMax.Value = 1;
@@ -170,10 +171,10 @@ namespace ShellFiler.UI.Dialog.Option {
             // checkBoxSeparateExt
             // 
             this.checkBoxSeparateExt.AutoSize = true;
-            this.checkBoxSeparateExt.Location = new System.Drawing.Point(9, 318);
-            this.checkBoxSeparateExt.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.checkBoxSeparateExt.Location = new System.Drawing.Point(8, 273);
+            this.checkBoxSeparateExt.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.checkBoxSeparateExt.Name = "checkBoxSeparateExt";
-            this.checkBoxSeparateExt.Size = new System.Drawing.Size(294, 34);
+            this.checkBoxSeparateExt.Size = new System.Drawing.Size(256, 29);
             this.checkBoxSeparateExt.TabIndex = 15;
             this.checkBoxSeparateExt.Text = "最後の拡張子を離して表示(&E)";
             this.checkBoxSeparateExt.UseVisualStyleBackColor = true;
@@ -181,10 +182,10 @@ namespace ShellFiler.UI.Dialog.Option {
             // checkBoxOppositeParent
             // 
             this.checkBoxOppositeParent.AutoSize = true;
-            this.checkBoxOppositeParent.Location = new System.Drawing.Point(9, 368);
-            this.checkBoxOppositeParent.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.checkBoxOppositeParent.Location = new System.Drawing.Point(8, 315);
+            this.checkBoxOppositeParent.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.checkBoxOppositeParent.Name = "checkBoxOppositeParent";
-            this.checkBoxOppositeParent.Size = new System.Drawing.Size(315, 34);
+            this.checkBoxOppositeParent.Size = new System.Drawing.Size(275, 29);
             this.checkBoxOppositeParent.TabIndex = 16;
             this.checkBoxOppositeParent.Text = "逆向き←→で親フォルダに戻る(&P)";
             this.checkBoxOppositeParent.UseVisualStyleBackColor = true;
@@ -192,10 +193,10 @@ namespace ShellFiler.UI.Dialog.Option {
             // checkBoxHideDrag
             // 
             this.checkBoxHideDrag.AutoSize = true;
-            this.checkBoxHideDrag.Location = new System.Drawing.Point(9, 457);
-            this.checkBoxHideDrag.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.checkBoxHideDrag.Location = new System.Drawing.Point(8, 392);
+            this.checkBoxHideDrag.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.checkBoxHideDrag.Name = "checkBoxHideDrag";
-            this.checkBoxHideDrag.Size = new System.Drawing.Size(376, 34);
+            this.checkBoxHideDrag.Size = new System.Drawing.Size(327, 29);
             this.checkBoxHideDrag.TabIndex = 18;
             this.checkBoxHideDrag.Text = "外部へのドラッグ中にShellFilerを隠す(&O)";
             this.checkBoxHideDrag.UseVisualStyleBackColor = true;
@@ -203,86 +204,98 @@ namespace ShellFiler.UI.Dialog.Option {
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(49, 49);
-            this.label9.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label9.Location = new System.Drawing.Point(42, 42);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(651, 30);
+            this.label9.Size = new System.Drawing.Size(565, 25);
             this.label9.TabIndex = 3;
             this.label9.Text = "カーソルを上下に移動したとき、画面の端に達する前にスクロールを開始します。";
             // 
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(49, 77);
-            this.label10.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label10.Location = new System.Drawing.Point(42, 66);
+            this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(315, 30);
+            this.label10.Size = new System.Drawing.Size(271, 25);
             this.label10.TabIndex = 4;
             this.label10.Text = "設定値の行数が画面端で残ります。";
             // 
             // label11
             // 
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(51, 490);
-            this.label11.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label11.Location = new System.Drawing.Point(44, 420);
+            this.label11.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(826, 30);
+            this.label11.Size = new System.Drawing.Size(711, 25);
             this.label11.TabIndex = 19;
             this.label11.Text = "ファイルのドロップ中、ウィンドウ外までカーソルが移動したとき、下にあるウィンドウにドロップできるように";
             // 
             // label12
             // 
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(51, 401);
-            this.label12.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label12.Location = new System.Drawing.Point(44, 344);
+            this.label12.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(771, 30);
+            this.label12.Size = new System.Drawing.Size(663, 25);
             this.label12.TabIndex = 17;
             this.label12.Text = "左ウィンドウで←キーを押したとき、右ウィンドウで→キーを押したときに親フォルダに移動します。";
             // 
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(51, 518);
-            this.label13.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label13.Location = new System.Drawing.Point(44, 444);
+            this.label13.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(348, 30);
+            this.label13.Size = new System.Drawing.Size(299, 25);
             this.label13.TabIndex = 20;
             this.label13.Text = "自動的にウィンドウを隠すことができます。";
             // 
             // label14
             // 
             this.label14.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.label14.Location = new System.Drawing.Point(86, 121);
-            this.label14.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label14.Location = new System.Drawing.Point(74, 104);
+            this.label14.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(700, 5);
+            this.label14.Size = new System.Drawing.Size(600, 4);
             this.label14.TabIndex = 5;
             // 
             // label15
             // 
             this.label15.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.label15.Location = new System.Drawing.Point(84, 290);
-            this.label15.Margin = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.label15.Location = new System.Drawing.Point(72, 249);
+            this.label15.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(700, 5);
+            this.label15.Size = new System.Drawing.Size(600, 4);
             this.label15.TabIndex = 14;
             // 
             // checkBoxResumeCursor
             // 
             this.checkBoxResumeCursor.AutoSize = true;
-            this.checkBoxResumeCursor.Location = new System.Drawing.Point(9, 564);
-            this.checkBoxResumeCursor.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.checkBoxResumeCursor.Location = new System.Drawing.Point(8, 483);
+            this.checkBoxResumeCursor.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.checkBoxResumeCursor.Name = "checkBoxResumeCursor";
-            this.checkBoxResumeCursor.Size = new System.Drawing.Size(564, 34);
+            this.checkBoxResumeCursor.Size = new System.Drawing.Size(492, 29);
             this.checkBoxResumeCursor.TabIndex = 21;
             this.checkBoxResumeCursor.Text = "フォルダ変更時にカーソル位置を過去にいたファイルに移動する(&R)";
             this.checkBoxResumeCursor.UseVisualStyleBackColor = true;
             // 
+            // checkFileListCursorOpenFolder
+            // 
+            this.checkFileListCursorOpenFolder.AutoSize = true;
+            this.checkFileListCursorOpenFolder.Location = new System.Drawing.Point(9, 531);
+            this.checkFileListCursorOpenFolder.Margin = new System.Windows.Forms.Padding(4);
+            this.checkFileListCursorOpenFolder.Name = "checkFileListCursorOpenFolder";
+            this.checkFileListCursorOpenFolder.Size = new System.Drawing.Size(397, 29);
+            this.checkFileListCursorOpenFolder.TabIndex = 22;
+            this.checkFileListCursorOpenFolder.Text = "フォルダオープン時にカーソル位置のフォルダを開く(&C)";
+            this.checkFileListCursorOpenFolder.UseVisualStyleBackColor = true;
+            // 
             // FileListActionPage
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(168F, 168F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.Controls.Add(this.checkFileListCursorOpenFolder);
             this.Controls.Add(this.checkBoxResumeCursor);
             this.Controls.Add(this.checkBoxHideDrag);
             this.Controls.Add(this.checkBoxOppositeParent);
@@ -306,9 +319,9 @@ namespace ShellFiler.UI.Dialog.Option {
             this.Controls.Add(this.label3);
             this.Controls.Add(this.label1);
             this.Font = new System.Drawing.Font("Yu Gothic UI", 9F);
-            this.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "FileListActionPage";
-            this.Size = new System.Drawing.Size(910, 648);
+            this.Size = new System.Drawing.Size(780, 584);
             ((System.ComponentModel.ISupportInitialize)(this.numericScrollMargin)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarWheel)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackBarDragMax)).EndInit();
@@ -341,7 +354,6 @@ namespace ShellFiler.UI.Dialog.Option {
         private System.Windows.Forms.Label label14;
         private System.Windows.Forms.Label label15;
         private System.Windows.Forms.CheckBox checkBoxResumeCursor;
-
-
+        private System.Windows.Forms.CheckBox checkFileListCursorOpenFolder;
     }
 }

--- a/Project/ShellFiler/src/UI/Dialog/Option/FileListActionPage.cs
+++ b/Project/ShellFiler/src/UI/Dialog/Option/FileListActionPage.cs
@@ -56,6 +56,7 @@ namespace ShellFiler.UI.Dialog.Option {
             this.checkBoxOppositeParent.Checked = config.ChdirParentOtherSideMove;
             this.checkBoxHideDrag.Checked = config.HideWindowDragDrop;
             this.checkBoxResumeCursor.Checked = config.ResumeFolderCursorFile;
+            this.checkFileListCursorOpenFolder.Checked = config.FileListCursorOpenFolder;
         }
 
         //=========================================================================================
@@ -93,6 +94,9 @@ namespace ShellFiler.UI.Dialog.Option {
             // フォルダ変更時にカーソル位置のレジュームを行うときtrue
             bool resumeCursor = this.checkBoxResumeCursor.Checked;
 
+            // フォルダオープン時にカーソル位置にあるフォルダを開くときtrue
+            bool fileListCursorOpenFolder = this.checkFileListCursorOpenFolder.Checked;
+
             // Configに反映
             Configuration.Current.ListViewScrollMarginLineCount = scrollMargin;
             Configuration.Current.MouseWheelMaxLines = wheelLines;
@@ -101,6 +105,7 @@ namespace ShellFiler.UI.Dialog.Option {
             Configuration.Current.ChdirParentOtherSideMove = chdir;
             Configuration.Current.HideWindowDragDrop = hideDrag;
             Configuration.Current.ResumeFolderCursorFile = resumeCursor;
+            Configuration.Current.FileListCursorOpenFolder = fileListCursorOpenFolder;
 
             return true;
         }


### PR DESCRIPTION
突然で申し訳ございません。表題のPRになります。

現在ファイルリストからフォルダをShift+Enterキーで開いた場合にカレントのフォルダを開く動作を行いますが、
カーソル行のフォルダを開く動作をするオプションを追加したい内容となります。(KFと同じ動作にしたい)
オプションの「ファイル一覧」→「動作」の最後に「フォルダオープン時にカーソル位置のフォルダを開く」を付け加えさせていただいております。(デフォルトは現状のカレントを開く動作になります)

お手数ですがよろしくお願いいたします。