### PR TITLE
ファイル・フォルダ名に特定文字が含まれる場合にコピー・移動に失敗する

### DIFF
--- a/Project/ShellFiler/src/Util/CopyFileEx.cs
+++ b/Project/ShellFiler/src/Util/CopyFileEx.cs
@@ -28,10 +28,10 @@ namespace ShellFiler.Util {
         private const uint PROGRESS_STOP = 2; 
         private const uint PROGRESS_QUIET = 3; 
 
-        [DllImport("kernel32.dll", SetLastError = true)] 
-        private static extern bool CopyFileEx(string lpExistingFileName, string lpNewFileName, CopyProgressRoutine lpProgressRoutine, IntPtr lpData, ref Int32 pbCancel, uint dwCopyFlags); 
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] 
+        private static extern bool CopyFileEx(string lpExistingFileName, string lpNewFileName, CopyProgressRoutine lpProgressRoutine, IntPtr lpData, ref Int32 pbCancel, uint dwCopyFlags);
 
-        [DllImport("kernel32.dll", SetLastError = true)] 
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] 
         private static extern bool MoveFileWithProgress(string lpExistingFileName, string lpNewFileName, CopyProgressRoutine lpProgressRoutine, IntPtr lpData, uint dwCopyFlags); 
 
         // 進捗状況のイベント通知先のメソッド型

--- a/Project/ShellFiler/src/Util/CopyFileEx.cs
+++ b/Project/ShellFiler/src/Util/CopyFileEx.cs
@@ -32,7 +32,7 @@ namespace ShellFiler.Util {
         private static extern bool CopyFileEx(string lpExistingFileName, string lpNewFileName, CopyProgressRoutine lpProgressRoutine, IntPtr lpData, ref Int32 pbCancel, uint dwCopyFlags);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)] 
-        private static extern bool MoveFileWithProgress(string lpExistingFileName, string lpNewFileName, CopyProgressRoutine lpProgressRoutine, IntPtr lpData, uint dwCopyFlags); 
+        private static extern bool MoveFileWithProgress(string lpExistingFileName, string lpNewFileName, CopyProgressRoutine lpProgressRoutine, IntPtr lpData, uint dwCopyFlags);
 
         // 進捗状況のイベント通知先のメソッド型
         private delegate uint CopyProgressRoutine(long totalSize, long transfered, long streamSize, long streamTransferred, uint streamNumber, uint reason, IntPtr hSrcFile, IntPtr hDestFile, IntPtr lpData);


### PR DESCRIPTION
たびたび申し訳ございません。こちらのPRもご確認いただけますと幸いです。

ファイル・フォルダ名にShift_JIS外の文字が使われている場合、
コピーや移動に実行できずに失敗してしまいます。(ヨーロッパ文字のアクセント付き文字「é」などの他言語文字が含まれる場合)
CopyFileEx、MoveFileWithProgress APIがANSI版利用によるようでUNICODE版に変更できればと思います。
リネームや削除などは可能ですので、あまり問題では無いのですがよろしくお願いいたします。

すみません。お手数ですがよろしくお願いいたします。